### PR TITLE
修复stopFlipping再重新startFlipping后展示的数据项下标错位的问题

### DIFF
--- a/MarqueeView/src/main/java/com/sunfusheng/marqueeview/MarqueeView.java
+++ b/MarqueeView/src/main/java/com/sunfusheng/marqueeview/MarqueeView.java
@@ -28,6 +28,7 @@ public class MarqueeView extends ViewFlipper {
     private int textSize = 14;
     private int textColor = 0xffffffff;
     private boolean singleLine = false;
+    private int totalViewCount = 3;
 
     private int gravity = Gravity.LEFT | Gravity.CENTER_VERTICAL;
     private static final int GRAVITY_LEFT = 0;
@@ -46,7 +47,6 @@ public class MarqueeView extends ViewFlipper {
     @AnimRes
     private int outAnimResId = R.anim.anim_top_out;
 
-    private int position;
     private List<? extends CharSequence> notices = new ArrayList<>();
     private OnItemClickListener onItemClickListener;
 
@@ -214,9 +214,11 @@ public class MarqueeView extends ViewFlipper {
     private void start(final @AnimRes int inAnimResId, final @AnimRes int outAnimResID) {
         removeAllViews();
         clearAnimation();
-
-        position = 0;
-        addView(createTextView(notices.get(position)));
+        // 检测数据源
+        if (notices == null || notices.isEmpty()) {
+            throw new RuntimeException("The data source cannot be empty!");
+        }
+        addView(createTextView(notices.get(0), 0));
 
         if (notices.size() > 1) {
             setInAndOutAnimation(inAnimResId, outAnimResID);
@@ -235,11 +237,11 @@ public class MarqueeView extends ViewFlipper {
 
                 @Override
                 public void onAnimationEnd(Animation animation) {
-                    position++;
-                    if (position >= notices.size()) {
+                    int position = getPosition(getCurrentView());
+                    if (++position >= notices.size()) {
                         position = 0;
                     }
-                    View view = createTextView(notices.get(position));
+                    View view = createTextView(notices.get(position), position);
                     if (view.getParent() == null) {
                         addView(view);
                     }
@@ -253,30 +255,30 @@ public class MarqueeView extends ViewFlipper {
         }
     }
 
-    private TextView createTextView(CharSequence text) {
-        TextView textView = (TextView) getChildAt((getDisplayedChild() + 1) % 3);
+    private TextView createTextView(CharSequence text, int realPosition) {
+        TextView textView = (TextView) getChildAt((getDisplayedChild() + 1) % totalViewCount);
         if (textView == null) {
             textView = new TextView(getContext());
             textView.setGravity(gravity);
             textView.setTextColor(textColor);
             textView.setTextSize(textSize);
             textView.setSingleLine(singleLine);
-        }
-        textView.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (onItemClickListener != null) {
-                    onItemClickListener.onItemClick(getPosition(), (TextView) v);
+            textView.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (onItemClickListener != null) {
+                        onItemClickListener.onItemClick(getPosition(v), (TextView) v);
+                    }
                 }
-            }
-        });
+            });
+        }
         textView.setText(text);
-        textView.setTag(position);
+        textView.setTag(realPosition);
         return textView;
     }
 
-    public int getPosition() {
-        return (int) getCurrentView().getTag();
+    private int getPosition(View view) {
+        return (int) view.getTag();
     }
 
     public List<? extends CharSequence> getNotices() {

--- a/Sample/src/main/java/com/sunfusheng/sample/fragment/CommonFragment.java
+++ b/Sample/src/main/java/com/sunfusheng/sample/fragment/CommonFragment.java
@@ -56,7 +56,7 @@ public class CommonFragment extends Fragment {
         marqueeView.setOnItemClickListener((position, textView) -> Toast.makeText(getContext(), textView.getText() + "", Toast.LENGTH_SHORT).show());
 
         marqueeView1.startWithText(getString(R.string.marquee_texts), R.anim.anim_top_in, R.anim.anim_bottom_out);
-        marqueeView1.setOnItemClickListener((position, textView) -> Toast.makeText(getContext(), String.valueOf(marqueeView1.getPosition()) + ". " + textView.getText(), Toast.LENGTH_SHORT).show());
+        marqueeView1.setOnItemClickListener((position, textView) -> Toast.makeText(getContext(), String.valueOf(position) + ". " + textView.getText(), Toast.LENGTH_SHORT).show());
 
         marqueeView2.startWithText(getString(R.string.marquee_text));
 


### PR DESCRIPTION
因为动画结束后position自加1，stop再重新start后position又加了1，导致直接跳到下下个text展示。